### PR TITLE
mysql: allow restricting databases in replication

### DIFF
--- a/cookbooks/mysql/recipes/server.rb
+++ b/cookbooks/mysql/recipes/server.rb
@@ -65,7 +65,10 @@ if gentoo?
     end
 
     systemd_tmpfiles "mysql"
-    systemd_unit "mysql.service"
+
+    systemd_unit "mysql.service" do
+      template true
+    end
 
     service "mysql" do
       action [:enable, :start]

--- a/cookbooks/mysql/templates/default/mysql.service
+++ b/cookbooks/mysql/templates/default/mysql.service
@@ -4,7 +4,11 @@ ConditionPathExists=/etc/mysql/my.cnf
 After=network.target
 
 [Service]
+<% if node[:mysql][:server][:replicate_do_db] %>
+ExecStart=/usr/sbin/mysqld --log-error=/dev/stderr <%= node[:mysql][:server][:replicate_do_db].map{|db| "--binlog-do-db=#{db} --replicate-do-db=#{db}" }.join(' ') %>
+<% else %>
 ExecStart=/usr/sbin/mysqld --log-error=/dev/stderr
+<% end %>
 ExecStartPost=/usr/libexec/mysqld-wait-ready $MAINPID
 Restart=always
 User=mysql


### PR DESCRIPTION
Currently node[:mysql][:server][:replicate_do_db] is only used for OSX, this patch enables it for gentoo.

It's not possible to set these options via client, you must configure the daemon.