### PR TITLE
zfs: move cmds to scripts and allow hard reboots

### DIFF
--- a/cookbooks/zfs/files/default/mount_zpools
+++ b/cookbooks/zfs/files/default/mount_zpools
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ -e /etc/zfs/zpools ] && /usr/bin/xargs -rn1 zpool import -f < /etc/zfs/zpools
+
+/sbin/zfs mount -a

--- a/cookbooks/zfs/files/default/unmount_zpools
+++ b/cookbooks/zfs/files/default/unmount_zpools
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+/sbin/zpool list -Ho name > /etc/zfs/zpools
+/sbin/zfs umount -a
+/usr/bin/xargs -rn1 /sbin/zpool export < /etc/zfs/zpools

--- a/cookbooks/zfs/recipes/default.rb
+++ b/cookbooks/zfs/recipes/default.rb
@@ -1,6 +1,18 @@
 if gentoo?
   package "sys-fs/zfs"
 
+  %w{
+   mount_zpools
+   unmount_zpools
+  }.each do |file|
+    cookbook_file "/etc/zfs/#{file}" do
+      source file
+      owner "root"
+      group "root"
+      mode "0544"
+    end
+  end
+
   systemd_unit "zfs.service" do
     template true
   end

--- a/cookbooks/zfs/templates/default/zfs.service
+++ b/cookbooks/zfs/templates/default/zfs.service
@@ -8,11 +8,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/sbin/modprobe zfs
 ExecStartPre=/usr/bin/test -c /dev/zfs
-ExecStartPre=/bin/sh -c "[ -e /etc/zfs/zpools ] && /usr/bin/xargs -rn1 zpool import < /etc/zfs/zpools"
-ExecStart=/sbin/zfs mount -a
-ExecStop=/bin/sh -c "/sbin/zpool list -Ho name > /etc/zfs/zpools"
-ExecStop=/sbin/zfs umount -a
-ExecStop=/bin/sh -c "/usr/bin/xargs -rn1 zpool export < /etc/zfs/zpools"
+ExecStartPre=/etc/zfs/mount_zpools
+ExecStop=/etc/zfs/unmount_zpools
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
while there are not many commands to execute, some needed string escaping.

This seems to differ between systemd versions to the point that it broke too often. Hence this patch moves it back into scripts to be executed.

Also, on hard reboot, zpool import requires -f to mount, so this patch also adds it.