### PR TITLE
duply: randomize startup to avoid a race on initial run

### DIFF
--- a/cookbooks/duply/providers/backup.rb
+++ b/cookbooks/duply/providers/backup.rb
@@ -26,7 +26,7 @@ action :create do
   end
 
   s = nr.schedule
-  s ||= %W(OnCalendar=#{node[:duply][:backup_time]})
+  s ||= %W(OnCalendar=#{node[:duply][:backup_time]} AccuracySec=1h)
 
   systemd_timer "duply-bkp-#{nr.name}" do
     schedule s
@@ -34,7 +34,7 @@ action :create do
   end
 
   systemd_timer "duply-purge-#{nr.name}" do
-    schedule %w(OnCalendar=weekly)
+    schedule %w(OnCalendar=weekly AccuracySec=1h)
     unit command: "/usr/bin/duply #{nr.name} purgeFull --force"
   end
 end


### PR DESCRIPTION
on initial run /root/.gnugp is generated, this is a race condition and often fails.

This patch tries to avoid that.