### PR TITLE
Consul and postgresql ha

### DIFF
--- a/cookbooks/consul/attributes/default.rb
+++ b/cookbooks/consul/attributes/default.rb
@@ -1,0 +1,13 @@
+default[:consul][:version] = "0.6.0"
+default[:consul][:encrypt] = "DrpzTIcZOBoVvlJ9jcwD/g=="
+default[:consul][:bind_addr] = node[:ipaddress]
+default[:consul][:bootstrap_expect] = 3
+
+default[:consul][:envconsul][:version] = "0.6.0"
+default[:consul][:template][:version] = "0.12.0"
+
+default[:consul][:dnsmasq][:repository] = "https://github.com/liquidm/dnsmasq.git"
+default[:consul][:dnsmasq][:version] = "production"
+
+default[:consul][:consulcli][:repository] = "https://github.com/liquidm/consul-cli.git"
+default[:consul][:consulcli][:revision] = "production"

--- a/cookbooks/consul/files/default/consul.service
+++ b/cookbooks/consul/files/default/consul.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Consul Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=consul
+Group=consul
+Environment=GOMAXPROCS=3
+ExecStart=/var/app/consul/current/consul agent -config-file=/var/app/consul/shared/config/config.json -config-dir=/var/app/consul/shared/config/services
+ExecReload=/var/app/consul/current/consul reload
+SyslogIdentifier=consul
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/cookbooks/consul/files/default/dnsmasq.service
+++ b/cookbooks/consul/files/default/dnsmasq.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Dnsmasq Agent
+After=network-online.target
+Wants=consul.target
+
+[Service]
+User=root
+Group=dnsmasq
+ExecStart=/var/app/dnsmasq/current/src/dnsmasq --server=/consul/127.0.0.1#8600 --server=8.8.8.8 --server=8.8.4.4 -d -R
+SyslogIdentifier=dnsmasq
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/cookbooks/consul/metadata.rb
+++ b/cookbooks/consul/metadata.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+name "consul"
+description "Consul.io"
+
+maintainer "LiquidM"
+maintainer_email "tech@liquidm.com"
+
+supports "gentoo"
+
+depends "deploy"

--- a/cookbooks/consul/recipes/default.rb
+++ b/cookbooks/consul/recipes/default.rb
@@ -1,0 +1,215 @@
+deploy_skeleton "consul"
+
+modules = {
+  consul: {
+    zip: "https://releases.hashicorp.com/consul/#{node[:consul][:version]}/consul_#{node[:consul][:version]}_linux_amd64.zip",
+    location: "/var/app/consul/releases/#{node[:consul][:version]}",
+    binary: "consul",
+  },
+  ui: {
+    zip: "https://releases.hashicorp.com/consul/#{node[:consul][:version]}/consul_#{node[:consul][:version]}_web_ui.zip",
+    location: "/var/app/consul/releases/#{node[:consul][:version]}/ui",
+    binary: "index.html",
+  },
+  envconsul: {
+    zip: "https://releases.hashicorp.com/envconsul/#{node[:consul][:envconsul][:version]}/envconsul_#{node[:consul][:envconsul][:version]}_linux_amd64.zip",
+    location: "/var/app/consul/releases/#{node[:consul][:version]}/envconsul-#{node[:consul][:envconsul][:version]}",
+    binary: "envconsul",
+    link_binary: true,
+  },
+  template: {
+    zip: "https://releases.hashicorp.com/consul-template/#{node[:consul][:template][:version]}/consul-template_#{node[:consul][:template][:version]}_linux_amd64.zip",
+    location: "/var/app/consul/releases/#{node[:consul][:version]}/consul-template-#{node[:consul][:template][:version]}",
+    binary: "consul-template",
+    link_binary: true,
+  },
+}
+
+extra_repos = {
+  consulcli: {
+    repository: node[:consul][:consulcli][:repository],
+    revision: node[:consul][:consulcli][:revision],
+    before_symlink: "make",
+    binaries: %w{
+      /var/app/consul/extras/consulcli/current/bin/consul-cli
+    }
+  }
+}
+
+data_dir = "/var/app/consul/shared/data"
+config_dir = "/var/app/consul/shared/config"
+service_dir = "/var/app/consul/shared/config/services"
+config_file = File.join(config_dir, "config.json")
+
+([data_dir, config_dir] + modules.map{|k,v| v[:location]}).each do |dir|
+  directory dir do
+    owner "consul"
+    group "consul"
+    mode "0755"
+    recursive true
+  end
+end
+
+# Make the service folder public, so e.g. HA daemons can update it
+directory service_dir do
+  owner "consul"
+  group "consul"
+  mode "0777"
+  recursive true
+end
+
+modules.each do |m, options|
+  basename = File.basename(options[:zip])
+  target_dir = options[:location]
+  target_binary = File.join(target_dir, options[:binary])
+  local_archive = File.join(target_dir, basename)
+
+  remote_file basename do
+    source options[:zip]
+    path local_archive
+    backup false
+    group "consul"
+    owner "consul"
+    mode "0644"
+  end
+
+  execute "extract #{basename}" do
+    command "unzip #{local_archive}"
+    cwd target_dir
+    creates target_binary
+    group "consul"
+    user "consul"
+  end
+
+  if options[:link_binary]
+    link "/var/app/consul/current/#{options[:binary]}" do
+      to target_binary
+    end
+  end
+end
+
+template File.join(modules[:consul][:location], "envconsul_lock") do
+  source "envconsul_lock"
+  group "consul"
+  owner "consul"
+  mode "0555"
+
+  variables({
+    release_path: modules[:consul][:location]
+  })
+end
+
+link "/var/app/consul/current" do
+  to modules[:consul][:location]
+end
+
+if gentoo?
+  template "/etc/env.d/97consul" do
+    source "97consul"
+    owner "root"
+    group "root"
+    mode 0644
+    notifies :run, 'execute[env-update]'
+  end
+end
+
+is_server = node.role?("consul-server")
+
+
+def consul_cluster(n)
+  n.production? ? n[:cluster][:name].gsub(".", "_") : "dev"
+end
+
+consul_config = {
+  bind_addr: node[:consul][:bind_addr],
+  client_addr: "0.0.0.0",
+  data_dir: data_dir,
+  ui_dir: File.join(modules[:ui][:location]),
+  datacenter: consul_cluster(node),
+  log_level: "WARN",
+  encrypt: node[:consul][:encrypt],
+  server: is_server,
+}
+
+
+all_servers = node.nodes.role("consul-server").map{|n| {fqdn: n[:fqdn], cluster: consul_cluster(n) }}
+local_servers = all_servers.select{|n| n[:fqdn] != node[:fqdn] && n[:cluster] == consul_cluster(node) }.map{|n| n[:fqdn]}
+wan_servers = all_servers.select{|n| n[:cluster] != consul_cluster(node) }.map{|n| n[:fqdn]}
+
+if local_servers.length > 0
+  consul_config[:retry_join] = local_servers
+end
+
+if is_server
+  consul_config[:bootstrap_expect] = node[:consul][:bootstrap_expect]
+
+  if wan_servers.length > 0
+    consul_config[:retry_join_wan] = wan_servers
+  end
+end
+
+file config_file do
+  owner "root"
+  group "root"
+  mode 0644
+
+  content JSON.pretty_generate(consul_config)
+end
+
+if systemd_running?
+  systemd_unit "consul.service"
+
+  service "consul" do
+    action [:start, :enable]
+
+    subscribes :restart, "systemd_unit[consul]", :delayed
+    subscribes :restart, "link[/var/app/consul/current]", :delayed
+    subscribes :restart, "file[#{config_file}]", :delayed
+  end
+end
+
+if gentoo?
+  gem_package "diplomat" do
+    action :install
+  end.run_action(:install)
+else
+  chef_gem "diplomat" do
+    action :install
+    compile_time true
+  end
+end
+
+require "diplomat"
+
+extra_repos.each do |repo, options|
+  deploy_branch "/var/app/consul/extras/#{repo}" do
+    repository options[:repository]
+    revision options[:revision]
+    user "consul"
+
+    symlink_before_migrate({})
+
+    before_symlink do
+      execute "clean-gopath-for-#{repo}" do
+        command "rm -rf /var/app/consul/.go/*"
+      end
+
+      execute "#{repo}-make" do
+        command options[:before_symlink]
+        cwd release_path
+        user "consul"
+        environment({
+          "HOME" => "/var/app/consul",
+          "GOPATH" => "/var/app/consul/.go",
+          "PATH" => "/var/app/consul/.go/bin:#{ENV['PATH']}",
+        })
+      end
+    end
+  end
+
+  options[:binaries].each do |binary|
+    link "/var/app/consul/current/#{File.basename(binary)}" do
+      to binary
+    end
+  end
+end

--- a/cookbooks/consul/recipes/dnsmasq.rb
+++ b/cookbooks/consul/recipes/dnsmasq.rb
@@ -1,0 +1,33 @@
+include_recipe "consul"
+
+deploy_skeleton "dnsmasq"
+
+deploy_application "dnsmasq" do
+  repository node[:consul][:dnsmasq][:repository]
+  revision node[:consul][:dnsmasq][:version]
+
+  before_symlink do
+    execute "build dnsmasq" do
+      command "make"
+      cwd release_path
+      group "dnsmasq"
+      user "dnsmasq"
+    end
+  end
+
+end
+
+if systemd_running?
+  systemd_unit "dnsmasq.service"
+
+  service "dnsmasq" do
+    action [:start, :enable]
+    subscribes :restart, "deploy_application[dnsmasq]", :delayed
+    subscribes :restart, "systemd_unit[dnsmasq]", :delayed
+  end
+
+  local_dns = %w{127.0.0.1 8.8.8.8 8.8.4.4}
+  if node[:resolv][:nameservers] != local_dns
+    node.set[:resolv][:nameservers] = local_dns
+  end
+end

--- a/cookbooks/consul/templates/default/97consul
+++ b/cookbooks/consul/templates/default/97consul
@@ -1,0 +1,2 @@
+PATH=/var/app/consul/current
+ROOTPATH=/var/app/consul/current

--- a/cookbooks/consul/templates/default/envconsul_lock
+++ b/cookbooks/consul/templates/default/envconsul_lock
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+PREFIX=$1
+shift
+PARAMS=$@
+
+exec <%= @release_path %>/consul lock $PREFIX <%= @release_path %>/envconsul -prefix $PREFIX $PARAMS

--- a/cookbooks/linux/templates/default/resolv.conf
+++ b/cookbooks/linux/templates/default/resolv.conf
@@ -1,4 +1,3 @@
-options rotate attempts:5 timeout:1
 <% node[:resolv][:nameservers].each do |ns| %>
 nameserver <%= ns %>
 <% end %>

--- a/cookbooks/postgresql-ha/attributes/default.rb
+++ b/cookbooks/postgresql-ha/attributes/default.rb
@@ -1,0 +1,37 @@
+# connection info (overriden in server recipe)
+default[:postgresql][:connection][:host] = 'localhost'
+default[:postgresql][:connection][:username] = 'postgres'
+default[:postgresql][:connection][:password] = ''
+
+# Connections and Authentication
+default[:postgresql][:server][:version] = "9.4"
+default[:postgresql][:server][:listen_address] = "0.0.0.0"
+default[:postgresql][:server][:port] = 5432
+default[:postgresql][:server][:max_connections] = 500
+default[:postgresql][:server][:authentication_timeout] = "1min"
+
+# Resource Consumption
+default[:postgresql][:server][:shared_buffers] = "#{[(node[:memory][:total].to_i/1024/4),130].max}MB"
+default[:postgresql][:server][:temp_buffers] = "8MB"
+default[:postgresql][:server][:work_mem] = "1MB"
+default[:postgresql][:server][:maintenance_work_mem] = "16MB"
+
+# Write Ahead Log
+default[:postgresql][:server][:wal_level] = "logical"
+default[:postgresql][:server][:wal_buffers] = -1
+default[:postgresql][:server][:checkpoint_segments] = 3
+default[:postgresql][:server][:checkpoint_completion_target] = 0.5
+default[:postgresql][:server][:max_wal_senders] = 10
+default[:postgresql][:server][:wal_keep_segments] = 1024 # 16G of segments
+default[:postgresql][:server][:max_replication_slots] = 5
+
+# Planner Cost Constants
+default[:postgresql][:server][:effective_cache_size] = "128MB"
+
+# Hourly snapshots
+default[:postgresql][:snapshot][:path] = "/var/app/postgresql/snapshots"
+
+# HA
+default[:postgresql][:ha][:cluster] = node[:cluster][:name]
+default[:postgresql][:ha][:pgbouncer] = "1.7"
+default[:postgresql][:ha][:client_port] = 6432

--- a/cookbooks/postgresql-ha/files/default/pgbouncer.service
+++ b/cookbooks/postgresql-ha/files/default/pgbouncer.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=PgBouncer
+After=network-online.target
+Wants=dnsmasq.service
+
+[Service]
+User=pgbouncer
+Group=pgbouncer
+ExecStart=/var/app/pgbouncer/current/pgbouncer /var/app/pgbouncer/shared/config/pgbouncer.ini
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+TimeoutSec=900
+OOMScoreAdjust=-990
+
+[Install]
+WantedBy=multi-user.target

--- a/cookbooks/postgresql-ha/files/default/postgresql.tmpfiles
+++ b/cookbooks/postgresql-ha/files/default/postgresql.tmpfiles
@@ -1,0 +1,4 @@
+# systemd tmpfile settings for postgresql
+# See tmpfiles.d(5) for details
+
+d /run/postgresql 0755 postgres postgres -

--- a/cookbooks/postgresql-ha/files/default/postgresql@.service
+++ b/cookbooks/postgresql-ha/files/default/postgresql@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Postgresql %i Database
+After=network.target
+
+[Service]
+User=postgres
+Group=postgres
+ExecStart=/bin/sh -c "/usr/lib/postgresql-%I/bin/postgres -D /var/lib/postgresql/%I/data"
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+TimeoutSec=900
+OOMScoreAdjust=-990
+SyslogIdentifier=postgres
+
+[Install]
+WantedBy=multi-user.target

--- a/cookbooks/postgresql-ha/metadata.rb
+++ b/cookbooks/postgresql-ha/metadata.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+name "postgresql-ha"
+description "PostgreSQL HA Database Server"
+
+maintainer "Hagen Rother"
+maintainer_email "hagen@rother.cc"
+license "Apache v2.0"
+
+supports "gentoo"
+depends "consul"

--- a/cookbooks/postgresql-ha/recipes/backup.rb
+++ b/cookbooks/postgresql-ha/recipes/backup.rb
@@ -1,0 +1,28 @@
+include_recipe "postgresql-ha"
+
+backupdir = "/var/app/postgresql/backup"
+
+directory backupdir do
+  owner "postgres"
+  group "postgres"
+  mode "0700"
+  recursive true
+end
+
+systemd_timer "postgresql-backup" do
+  schedule %w(OnCalendar=daily)
+  unit({
+    command: [
+      "/bin/bash -c 'rm -rf #{backupdir}/*'",
+      "/usr/bin/pg_basebackup -D #{backupdir} --xlog-method=stream",
+    ],
+    user: "postgres",
+    group: "postgres",
+  })
+end
+
+duply_backup "postgresql" do
+  source backupdir
+  max_full_backups 30
+  incremental false
+end

--- a/cookbooks/postgresql-ha/recipes/client.rb
+++ b/cookbooks/postgresql-ha/recipes/client.rb
@@ -1,0 +1,50 @@
+package "net-dns/c-ares"
+package "dev-libs/libevent"
+
+tar_url = "http://pgbouncer.github.io/downloads/files/#{node[:postgresql][:ha][:pgbouncer]}/pgbouncer-#{node[:postgresql][:ha][:pgbouncer]}.tar.gz"
+binary = "/var/app/pgbouncer/releases/pgbouncer-#{node[:postgresql][:ha][:pgbouncer]}/pgbouncer"
+release_dir = File.dirname(binary)
+basename = File.basename(tar_url)
+
+deploy_skeleton "pgbouncer"
+
+tar_extract tar_url do
+  target_dir "/var/app/pgbouncer/releases"
+  user "pgbouncer"
+  group "pgbouncer"
+
+  not_if do
+    File.exists?(binary)
+  end
+end
+
+execute "pgbouncer-build" do
+  not_if do
+    File.exists?(binary)
+  end
+
+  command "/bin/bash -l -c './configure && make'"
+  cwd release_dir
+  user "pgbouncer"
+  group "pgbouncer"
+end
+
+link "/var/app/pgbouncer/current" do
+  to release_dir
+  notifies :restart, "service[pgbouncer]", :delayed
+end
+
+template "/var/app/pgbouncer/shared/config/pgbouncer.ini" do
+  source "pgbouncer.ini"
+  owner "pgbouncer"
+  group "pgbouncer"
+  mode "0444"
+
+  notifies :reload, "service[pgbouncer]", :delayed
+end
+
+systemd_unit "pgbouncer.service"
+
+service "pgbouncer" do
+  action [:enable, :start]
+end

--- a/cookbooks/postgresql-ha/recipes/default.rb
+++ b/cookbooks/postgresql-ha/recipes/default.rb
@@ -1,0 +1,2 @@
+package "dev-db/postgresql"
+package "dev-ruby/pg"

--- a/cookbooks/postgresql-ha/recipes/server.rb
+++ b/cookbooks/postgresql-ha/recipes/server.rb
@@ -1,0 +1,84 @@
+include_recipe "postgresql-ha"
+include_recipe "consul"
+
+version = node[:postgresql][:server][:version]
+homedir = "/var/lib/postgresql/#{version}"
+datadir = "#{homedir}/data"
+
+node.set[:postgresql][:connection][:host] = node[:fqdn]
+
+[
+  "/var/app/postgresql",
+  "/var/app/postgresql/template",
+  "/var/lib/postgresql",
+  homedir
+].each do |psql_dir|
+  directory psql_dir do
+    owner "postgres"
+    group "postgres"
+    mode "0700"
+    recursive true
+  end
+end
+
+%w{
+  pg_hba.conf.ctmpl
+  pg_ident.conf.ctmpl
+  postgresql.conf.ctmpl
+  postgresql-ha-master.json.ctmpl
+  postgresql-ha-slave.json.ctmpl
+  recovery.conf.ctmpl
+}.each do |ctmpl|
+  template "/var/app/postgresql/template/#{ctmpl}" do
+    source ctmpl
+    owner "postgres"
+    group "postgres"
+    mode "0444"
+  end
+end
+
+sudo_rule "postgres-ha" do
+  user "postgres"
+  runas "ALL"
+  command "NOPASSWD:/usr/bin/systemctl *"
+end
+
+template "/var/lib/postgresql/postgresql-ha" do
+  source "postgresql-ha.sh"
+  owner "postgres"
+  group "postgres"
+  mode "0544"
+
+  notifies :restart, "service[postgresql-ha]", :delayed
+end
+
+%w{
+  postgresql-ha-check-master.sh
+  postgresql-ha-check-slave.sh
+}.each do |check_file|
+  template "/var/app/consul/shared/config/services/#{check_file}" do
+    source check_file
+    owner "consul"
+    group "consul"
+    mode "0544"
+
+    notifies :reload, "service[consul]", :delayed
+  end
+end
+
+systemd_tmpfiles "postgresql"
+systemd_unit "postgresql@.service"
+
+# postgresql must not auto-start, postgresql-ha will do that
+service "postgresql" do
+  service_name "postgresql@#{version}.service"
+  action [:disable]
+end
+
+systemd_unit "postgresql-ha.service" do
+  template true
+end
+
+service "postgresql-ha" do
+  action [:enable, :start]
+end

--- a/cookbooks/postgresql-ha/recipes/snapshot.rb
+++ b/cookbooks/postgresql-ha/recipes/snapshot.rb
@@ -1,0 +1,26 @@
+include_recipe "postgresql"
+
+directory node[:postgresql][:snapshot][:path] do
+  owner "postgres"
+  group "postgres"
+  mode "0700"
+  recursive true
+end
+
+template "/var/app/postgresql/postgres-snapshot" do
+  source "postgres-snapshot.sh"
+  owner "postgres"
+  group "postgres"
+  mode "0544"
+end
+
+systemd_timer "postgresql-snapshot" do
+  schedule %w(OnCalendar=hourly)
+  unit({
+    command: [
+      "/var/app/postgresql/postgres-snapshot"
+    ],
+    user: "postgres",
+    group: "postgres",
+  })
+end

--- a/cookbooks/postgresql-ha/templates/default/pg_hba.conf.ctmpl
+++ b/cookbooks/postgresql-ha/templates/default/pg_hba.conf.ctmpl
@@ -1,0 +1,85 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local      DATABASE  USER  METHOD  [OPTIONS]
+# host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# plain TCP/IP socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "gss", "sspi",
+# "krb5", "ident", "peer", "pam", "ldap", "radius" or "cert".  Note that
+# "password" sends passwords in clear text; "md5" is preferred since
+# it sends encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can
+# use "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+# CAUTION: Configuring the system for local "trust" authentication
+# allows any local user to connect as any PostgreSQL user, including
+# the database superuser.  If you do not trust all your local users,
+# use another authentication method.
+
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+local   all             all                                     trust
+local   replication     all                                     trust
+host    all             all             0.0.0.0/0               trust
+host    replication     all             0.0.0.0/0               trust

--- a/cookbooks/postgresql-ha/templates/default/pg_ident.conf.ctmpl
+++ b/cookbooks/postgresql-ha/templates/default/pg_ident.conf.ctmpl
@@ -1,0 +1,42 @@
+# PostgreSQL User Name Maps
+# =========================
+#
+# Refer to the PostgreSQL documentation, chapter "Client
+# Authentication" for a complete description.  A short synopsis
+# follows.
+#
+# This file controls PostgreSQL user name mapping.  It maps external
+# user names to their corresponding PostgreSQL user names.  Records
+# are of the form:
+#
+# MAPNAME  SYSTEM-USERNAME  PG-USERNAME
+#
+# (The uppercase quantities must be replaced by actual values.)
+#
+# MAPNAME is the (otherwise freely chosen) map name that was used in
+# pg_hba.conf.  SYSTEM-USERNAME is the detected user name of the
+# client.  PG-USERNAME is the requested PostgreSQL user name.  The
+# existence of a record specifies that SYSTEM-USERNAME may connect as
+# PG-USERNAME.
+#
+# If SYSTEM-USERNAME starts with a slash (/), it will be treated as a
+# regular expression.  Optionally this can contain a capture (a
+# parenthesized subexpression).  The substring matching the capture
+# will be substituted for \1 (backslash-one) if present in
+# PG-USERNAME.
+#
+# Multiple maps may be specified in this file and used by pg_hba.conf.
+#
+# No map names are defined in the default configuration.  If all
+# system user names and PostgreSQL user names are the same, you don't
+# need anything in this file.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can
+# use "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+
+# MAPNAME       SYSTEM-USERNAME         PG-USERNAME

--- a/cookbooks/postgresql-ha/templates/default/pgbouncer.ini
+++ b/cookbooks/postgresql-ha/templates/default/pgbouncer.ini
@@ -1,0 +1,10 @@
+[databases]
+* = host=postgres-<%= node[:postgresql][:ha][:cluster] %>.service.consul user=postgres
+
+[pgbouncer]
+pool_mode = transaction
+listen_port = <%= node[:postgresql][:ha][:client_port] %>
+listen_addr = *
+auth_type = any
+dns_max_ttl = 1
+dns_nxdomain_ttl = 1

--- a/cookbooks/postgresql-ha/templates/default/postgres-snapshot.sh
+++ b/cookbooks/postgresql-ha/templates/default/postgres-snapshot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+HOUR=`/bin/date +%k`00
+
+cd <%= node[:postgresql][:snapshot][:path] %>
+/bin/rm -rf ${HOUR}
+/bin/mkdir -p ${HOUR}
+exec /usr/bin/pg_basebackup -D ${HOUR} --xlog-method=stream

--- a/cookbooks/postgresql-ha/templates/default/postgresql-ha-check-master.sh
+++ b/cookbooks/postgresql-ha/templates/default/postgresql-ha-check-master.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+DAEMON=${1:-postgresql@9.4}
+
+function psql_get {
+  psql -U postgres -t -P format=unaligned -c "$1"
+}
+
+systemctl status $DAEMON > /dev/null
+if [[ $? -eq 0 ]]; then
+  if [[ $( psql_get "SELECT pg_is_in_recovery();" ) == "f" ]]; then
+    exit 0
+  fi
+fi
+
+exit 2

--- a/cookbooks/postgresql-ha/templates/default/postgresql-ha-check-slave.sh
+++ b/cookbooks/postgresql-ha/templates/default/postgresql-ha-check-slave.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+DAEMON=${1:-postgresql@9.4}
+
+function psql_get {
+  psql -U postgres -t -P format=unaligned -c "$1"
+}
+
+systemctl status $DAEMON > /dev/null
+if [[ $? -eq 0 ]]; then
+  if [[ $( psql_get "SELECT pg_is_in_recovery();" ) == "t" ]]; then
+    exit 0
+  fi
+fi
+
+exit 2

--- a/cookbooks/postgresql-ha/templates/default/postgresql-ha-master.json.ctmpl
+++ b/cookbooks/postgresql-ha/templates/default/postgresql-ha-master.json.ctmpl
@@ -1,0 +1,14 @@
+{
+  "service": {
+    "name": "postgresql-{{env "CLUSTER" | toLower }}",
+    "address": <%= node[:ipaddress].to_json %>,
+    "port": 5432,
+    "tags": ["master"],
+    "checks": [
+      {
+        "script": "/var/app/consul/shared/config/services/postgresql-ha-check-master.sh",
+        "interval": "1s"
+      }
+    ]
+  }
+}

--- a/cookbooks/postgresql-ha/templates/default/postgresql-ha-slave.json.ctmpl
+++ b/cookbooks/postgresql-ha/templates/default/postgresql-ha-slave.json.ctmpl
@@ -1,0 +1,14 @@
+{
+  "service": {
+    "name": "postgresql-{{env "CLUSTER" | toLower }}",
+    "address": <%= node[:ipaddress].to_json %>,
+    "port": 5432,
+    "tags": ["slave"],
+    "checks": [
+      {
+        "script": "/var/app/consul/shared/config/services/postgresql-ha-check-slave.sh",
+        "interval": "1s"
+      }
+    ]
+  }
+}

--- a/cookbooks/postgresql-ha/templates/default/postgresql-ha.service
+++ b/cookbooks/postgresql-ha/templates/default/postgresql-ha.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Postgresql %i HA Watch Daemon
+After=consul.service
+Wants=consul.service
+
+[Service]
+User=postgres
+Group=postgres
+ExecStart=/var/lib/postgresql/postgresql-ha
+Restart=always
+TimeoutSec=900
+OOMScoreAdjust=-990
+
+[Install]
+WantedBy=multi-user.target

--- a/cookbooks/postgresql-ha/templates/default/postgresql-ha.sh
+++ b/cookbooks/postgresql-ha/templates/default/postgresql-ha.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+CLUSTER=${1:-<%= node[:postgresql][:ha][:cluster] %>}
+PGDATA=${2:-/var/lib/postgresql/<%= node[:postgresql][:server][:version] %>/data}
+DAEMON=${3:-postgresql@<%= node[:postgresql][:server][:version] %>.service}
+CONSUL_SERVICE=/var/app/consul/shared/config/services/postgresql-ha.json
+
+KV_MASTER="postgresql/${CLUSTER}/master"
+HOSTNAME=`hostname -f`
+
+function psql_get {
+  /usr/bin/psql -U postgres -t -P format=unaligned -c "$1"
+}
+
+function check_master {
+  MASTER_UP=false
+  if [[ $( /usr/bin/psql -U postgres -h $MASTER -t -P format=unaligned -c "SELECT pg_is_in_recovery();" ) == "f" ]]; then
+    MASTER_UP=true
+  fi
+}
+
+function check_daemon {
+  DAEMON_UP=false
+  DAEMON_MASTER=false
+  psql_get "select true;" > /dev/null
+  if [[ $? -eq 0 ]]; then
+    DAEMON_UP=true
+    if [[ $( psql_get "SELECT pg_is_in_recovery();" ) == "f" ]]; then
+      DAEMON_MASTER=true
+    fi
+  fi
+}
+
+function init_config {
+  /var/app/consul/current/consul-template -once \
+    -template=/var/app/postgresql/template/pg_hba.conf.ctmpl:$PGDATA/pg_hba.conf \
+    -template=/var/app/postgresql/template/pg_ident.conf.ctmpl:$PGDATA/pg_ident.conf \
+    -template=/var/app/postgresql/template/postgresql.conf.ctmpl:$PGDATA/postgresql.conf
+}
+
+function init_master {
+    echo "adding a service to consul so I can be found"
+    env CLUSTER=$CLUSTER /var/app/consul/current/consul-template -once \
+      -template=/var/app/postgresql/template/postgresql-ha-master.json.ctmpl:$CONSUL_SERVICE
+    sudo systemctl reload consul
+
+    if [[ ! -a ${PGDATA}/PG_VERSION ]]; then
+      echo "initial bootstrap, initializing..."
+      /usr/bin/initdb --pgdata $PGDATA --locale=en_US.UTF-8 || exit 1
+    fi
+
+    init_config
+    check_daemon
+
+    if [ "$DAEMON_UP" == "false" ]; then
+      rm -f $PGDATA/recovery.conf
+      echo "(re-)starting $DAEMON"
+      sudo systemctl restart $DAEMON
+    elif [ "$DAEMON_MASTER" == "false" ]; then
+      echo "promoting $DAEMON to master"
+      /usr/bin/pg_ctl promote -D $PGDATA
+    else
+      echo "reloading $DAEMON to make sure it got a proper config"
+      sudo systemctl reload $DAEMON
+    fi
+}
+
+function elect_master {
+  SESSION=`/var/app/consul/current/consul-cli kv-lock --ttl=60s --lock-delay=0 $KV_MASTER`
+  if [[ "$?" != "0" ]]; then
+    CONSUL_UP=false
+    return
+  else
+    CONSUL_UP=true
+  fi
+  MASTER=`/var/app/consul/current/consul-cli kv-read $KV_MASTER`
+  if [[ "$?" != "0" ]]; then
+    CONSUL_UP=false
+    return
+  else
+    CONSUL_UP=true
+  fi
+
+  FORCE_MASTER=false
+
+  if [[ "$MASTER" == "" ]]; then
+    echo "first election, I am master then"
+    FORCE_MASTER=true
+  elif [[ $HOSTNAME != $MASTER ]]; then
+    check_master
+    if [[ "$MASTER_UP" == "false" ]]; then
+      echo "master $MASTER is not up... :("
+      check_daemon
+      if [[ "$DAEMON_UP" == "true" ]]; then
+        echo "but I am up, so I'll become master now"
+        FORCE_MASTER=true
+      else
+        echo "and I am also down, oh no!"
+      fi
+    fi
+  fi
+
+  if [[ "$FORCE_MASTER" == "true" ]]; then
+    MASTER=$HOSTNAME
+    /var/app/consul/current/consul-cli kv-write $KV_MASTER $MASTER
+    if [[ "$?" != "0" ]]; then
+      CONSUL_UP=false
+      return
+    else
+      CONSUL_UP=true
+    fi
+
+    echo "I am master now"
+    init_master
+    echo "holding the election lock for 20sec so my daemon can start up"
+    sleep 20
+    check_master
+    check_daemon
+    echo "done, daemon up==$DAEMON_UP, master==$DAEMON_MASTER; master $MASTER accessible==$MASTER_UP"
+  fi
+  /var/app/consul/current/consul-cli kv-unlock --session=$SESSION $KV_MASTER
+}
+
+function ensure_slave {
+  env CLUSTER=$CLUSTER /var/app/consul/current/consul-template -once \
+    -template=/var/app/postgresql/template/postgresql-ha-slave.json.ctmpl:$CONSUL_SERVICE:'sudo systemctl reload consul'
+
+  check_daemon
+
+  if [[ "$DAEMON_MASTER" == "true" ]]; then
+    # kill early, so consul down doesn't delay it
+    echo "I am supposed to be slave, but $DAEMON reports to be master, stopping it NOW"
+    sudo systemctl stop $DAEMON
+    rm -f $PGDATA/recovery.conf # ensure we will eventually restart as slave
+  fi
+
+  OLD_RECOVERY=`cat $PGDATA/recovery.conf 2>/dev/null`
+
+  # sadly, the output of -dry can't be compared directly, so detouring through .expected file
+  /var/app/consul/current/consul-template -once \
+    -template=/var/app/postgresql/template/recovery.conf.ctmpl:$PGDATA/recovery.expected
+  if [[ "$?" != "0" ]]; then
+    echo "consul seems down, skipping slave setup"
+    return
+  fi
+  NEW_RECOVERY=`cat $PGDATA/recovery.expected`
+
+  if [ "$OLD_RECOVERY" != "$NEW_RECOVERY" ] || [ "$DAEMON_MASTER" == "true" ]; then
+    echo "old recovery.conf"
+    echo $OLD_RECOVERY
+    echo "new recovery.conf"
+    echo $NEW_RECOVERY
+    echo .
+    echo "stopping $DAEMON"
+    sudo systemctl stop $DAEMON
+
+    echo "moving old $PGDATA to /var/app/postgresql/crashed"
+    mkdir -p /var/app/postgresql/crashed
+    mv $PGDATA /var/app/postgresql/crashed/`date +%Y-%M-%d-%k-%m-%S`
+
+    echo "taking a base backup from $MASTER"
+    /usr/bin/pg_basebackup -h $MASTER -D $PGDATA -v -P -U postgres --xlog-method=stream
+    if [[ "$?" == "0" ]]; then
+      echo "updating init files"
+      init_config
+      echo "setting up recovery.conf for master $MASTER"
+      /var/app/consul/current/consul-template -once \
+        -template=/var/app/postgresql/template/recovery.conf.ctmpl:$PGDATA/recovery.conf
+      if [[ "$?" != "0" ]]; then
+        echo "consul seems down, skipping slave setup"
+        rm -f $PGDATA/recovery.conf
+        return
+      fi
+      echo "starting $DAEMON in slave mode"
+      sudo systemctl start $DAEMON
+      echo "sleeping 20secs for dust to settle"
+      sleep 20
+      check_master
+      check_daemon
+      echo "done, daemon up==$DAEMON_UP, master==$DAEMON_MASTER; master $MASTER accessible==$MASTER_UP"
+    else
+      echo "taking base backup failed, not starting slave"
+    fi
+  fi
+}
+
+elect_master
+echo "postgresql-ha in cluster $CLUSTER, data in $PGDATA, master is $MASTER"
+
+while :
+do
+  elect_master
+  if [[ "$CONSUL_UP" == false ]]; then
+    echo "oh no, consul is down..."
+  elif [[ $HOSTNAME != $MASTER ]]; then
+    ensure_slave
+  elif [[ "$MASTER_UP" == "false" ]]; then
+    echo "my daemon is down... waiting for a slave to become master"
+  fi
+  sleep 1
+done

--- a/cookbooks/postgresql-ha/templates/default/postgresql.conf.ctmpl
+++ b/cookbooks/postgresql-ha/templates/default/postgresql.conf.ctmpl
@@ -1,0 +1,612 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'   # use data in another directory
+          # (change requires restart)
+#hba_file = 'ConfigDir/pg_hba.conf' # host-based authentication file
+          # (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf' # ident configuration file
+          # (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''     # write an extra PID file
+          # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '<%= node[:postgresql][:server][:listen_address] %>'   # what IP address(es) to listen on;
+          # comma-separated list of addresses;
+          # defaults to 'localhost'; use '*' for all
+          # (change requires restart)
+port = <%= node[:postgresql][:server][:port] %>       # (change requires restart)
+max_connections = <%= node[:postgresql][:server][:max_connections] %>     # (change requires restart)
+# Note:  Increasing max_connections costs ~400 bytes of shared memory per
+# connection slot, plus lock space (see max_locks_per_transaction).
+#superuser_reserved_connections = 3 # (change requires restart)
+#unix_socket_directories = '/run/postgresql'  # comma-separated list of directories
+          # (change requires restart)
+#unix_socket_group = ''     # (change requires restart)
+#unix_socket_permissions = 0777   # begin with 0 to use octal notation
+          # (change requires restart)
+#bonjour = off        # advertise server via Bonjour
+          # (change requires restart)
+#bonjour_name = ''      # defaults to the computer name
+          # (change requires restart)
+
+# - Security and Authentication -
+
+authentication_timeout = <%= node[:postgresql][:server][:authentication_timeout] %>   # 1s-600s
+#ssl = off        # (change requires restart)
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+          # (change requires restart)
+#ssl_prefer_server_ciphers = on   # (change requires restart)
+#ssl_ecdh_curve = 'prime256v1'    # (change requires restart)
+#ssl_renegotiation_limit = 512MB  # amount of data between renegotiations
+#ssl_cert_file = 'server.crt'   # (change requires restart)
+#ssl_key_file = 'server.key'    # (change requires restart)
+#ssl_ca_file = ''     # (change requires restart)
+#ssl_crl_file = ''      # (change requires restart)
+#password_encryption = on
+#db_user_namespace = off
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = ''
+#krb_caseins_users = off
+
+# - TCP Keepalives -
+# see "man 7 tcp" for details
+
+#tcp_keepalives_idle = 0    # TCP_KEEPIDLE, in seconds;
+          # 0 selects the system default
+#tcp_keepalives_interval = 0    # TCP_KEEPINTVL, in seconds;
+          # 0 selects the system default
+#tcp_keepalives_count = 0   # TCP_KEEPCNT;
+          # 0 selects the system default
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = <%= node[:postgresql][:server][:shared_buffers] %>     # min 128kB
+          # (change requires restart)
+#huge_pages = try     # on, off, or try
+          # (change requires restart)
+temp_buffers = <%= node[:postgresql][:server][:temp_buffers] %>     # min 800kB
+#max_prepared_transactions = 0    # zero disables the feature
+          # (change requires restart)
+# Note:  Increasing max_prepared_transactions costs ~600 bytes of shared memory
+# per transaction slot, plus lock space (see max_locks_per_transaction).
+# It is not advisable to set max_prepared_transactions nonzero unless you
+# actively intend to use prepared transactions.
+work_mem = <%= node[:postgresql][:server][:work_mem] %>       # min 64kB
+maintenance_work_mem = <%= node[:postgresql][:server][:maintenance_work_mem] %>   # min 1MB
+#autovacuum_work_mem = -1   # min 1MB, or -1 to use maintenance_work_mem
+#max_stack_depth = 2MB      # min 100kB
+#dynamic_shared_memory_type = posix # the default is the first option
+          # supported by the operating system:
+          #   posix
+          #   sysv
+          #   windows
+          #   mmap
+          # use none to disable dynamic shared memory
+
+# - Disk -
+
+#temp_file_limit = -1     # limits per-session temp file space
+          # in kB, or -1 for no limit
+
+# - Kernel Resource Usage -
+
+#max_files_per_process = 1000   # min 25
+          # (change requires restart)
+#shared_preload_libraries = ''    # (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0      # 0-100 milliseconds
+#vacuum_cost_page_hit = 1   # 0-10000 credits
+#vacuum_cost_page_miss = 10   # 0-10000 credits
+#vacuum_cost_page_dirty = 20    # 0-10000 credits
+#vacuum_cost_limit = 200    # 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms     # 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100    # 0-1000 max buffers written/round
+#bgwriter_lru_multiplier = 2.0    # 0-10.0 multipler on buffers scanned/round
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1   # 1-1000; 0 disables prefetching
+#max_worker_processes = 8
+
+
+#------------------------------------------------------------------------------
+# WRITE AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+wal_level = <%= node[:postgresql][:server][:wal_level] %>     # minimal, archive, or hot_standby
+          # (change requires restart)
+#fsync = on       # turns forced synchronization on or off
+#synchronous_commit = on    # synchronization level;
+          # off, local, remote_write, or on
+#wal_sync_method = fsync    # the default is the first option
+          # supported by the operating system:
+          #   open_datasync
+          #   fdatasync (default on Linux)
+          #   fsync
+          #   fsync_writethrough
+          #   open_sync
+#full_page_writes = on      # recover from partial page writes
+#wal_log_hints = off      # also do full page writes of non-critical updates
+wal_buffers = <%= node[:postgresql][:server][:wal_buffers] %>     # min 32kB, -1 sets based on shared_buffers
+          # (change requires restart)
+#wal_writer_delay = 200ms   # 1-10000 milliseconds
+
+#commit_delay = 0     # range 0-100000, in microseconds
+#commit_siblings = 5      # range 1-1000
+
+# - Checkpoints -
+
+checkpoint_segments = <%= node[:postgresql][:server][:checkpoint_segments] %>   # in logfile segments, min 1, 16MB each
+#checkpoint_timeout = 5min    # range 30s-1h
+checkpoint_completion_target = <%= node[:postgresql][:server][:checkpoint_completion_target] %> # checkpoint target duration, 0.0 - 1.0
+#checkpoint_warning = 30s   # 0 disables
+
+# - Archiving -
+
+#archive_mode = on    # allows archiving to be done
+        # (change requires restart)
+#archive_command = 'test ! -f <%= @datadir %>/pg_log_archive/%f && cp %p <%= @datadir %>/pg_log_archive/%f'   # command to use to archive a logfile segment
+        # placeholders: %p = path of file to archive
+        #               %f = file name only
+        # e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0    # force a logfile segment switch after this
+        # number of seconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Server(s) -
+
+# Set these on the master and on any standby that will send replication data.
+
+max_wal_senders = <%= node[:postgresql][:server][:max_wal_senders] %>   # max number of walsender processes
+        # (change requires restart)
+wal_keep_segments = <%= node[:postgresql][:server][:wal_keep_segments] %>   # in logfile segments, 16MB each; 0 disables
+#wal_sender_timeout = 60s # in milliseconds; 0 disables
+
+max_replication_slots = <%= node[:postgresql][:server][:max_replication_slots] %> # max number of replication slots
+        # (change requires restart)
+
+# - Master Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = '' # standby servers that provide sync rep
+        # comma-separated list of application_name
+        # from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0 # number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a master server.
+
+hot_standby = on  # "on" allows queries during recovery
+          # (change requires restart)
+#max_standby_archive_delay = 30s  # max delay before canceling queries
+          # when reading WAL from archive;
+          # -1 allows indefinite delay
+#max_standby_streaming_delay = 30s  # max delay before canceling queries
+          # when reading streaming WAL;
+          # -1 allows indefinite delay
+#wal_receiver_status_interval = 10s # send replies at least this often
+          # 0 disables
+hot_standby_feedback = on  # send info from standby to prevent
+          # query conflicts
+#wal_receiver_timeout = 60s   # time that receiver waits for
+          # communication from master
+          # in milliseconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0      # measured on an arbitrary scale
+#random_page_cost = 4.0     # same scale as above
+#cpu_tuple_cost = 0.01      # same scale as above
+#cpu_index_tuple_cost = 0.005   # same scale as above
+#cpu_operator_cost = 0.0025   # same scale as above
+effective_cache_size = <%= node[:postgresql][:server][:effective_cache_size] %>
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5      # range 1-10
+#geqo_pool_size = 0     # selects default based on effort
+#geqo_generations = 0     # selects default based on effort
+#geqo_selection_bias = 2.0    # range 1.5-2.0
+#geqo_seed = 0.0      # range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100  # range 1-10000
+#constraint_exclusion = partition # on, off, or partition
+#cursor_tuple_fraction = 0.1    # range 0.0-1.0
+#from_collapse_limit = 8
+#join_collapse_limit = 8    # 1 disables collapsing of explicit
+          # JOIN clauses
+
+
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'   # Valid values are combinations of
+          # stderr, csvlog, syslog, and eventlog,
+          # depending on platform.  csvlog
+          # requires logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off    # Enable capturing of stderr and csvlog
+          # into log files. Required to be on for
+          # csvlogs.
+          # (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'pg_log'   # directory where log files are written,
+          # can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'  # log file name pattern,
+          # can include strftime() escapes
+#log_file_mode = 0600     # creation mode for log files,
+          # begin with 0 to use octal notation
+#log_truncate_on_rotation = off   # If on, an existing log file with the
+          # same name as the new log file will be
+          # truncated rather than appended to.
+          # But such truncation only occurs on
+          # time-driven rotation, not on restarts
+          # or size-driven rotation.  Default is
+          # off, meaning append to existing files
+          # in all cases.
+#log_rotation_age = 1d      # Automatic rotation of logfiles will
+          # happen after that time.  0 disables.
+#log_rotation_size = 10MB   # Automatic rotation of logfiles will
+          # happen after that much log output.
+          # 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+
+# This is only relevant when logging to eventlog (win32):
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#client_min_messages = notice   # values in order of decreasing detail:
+          #   debug5
+          #   debug4
+          #   debug3
+          #   debug2
+          #   debug1
+          #   log
+          #   notice
+          #   warning
+          #   error
+
+#log_min_messages = warning   # values in order of decreasing detail:
+          #   debug5
+          #   debug4
+          #   debug3
+          #   debug2
+          #   debug1
+          #   info
+          #   notice
+          #   warning
+          #   error
+          #   log
+          #   fatal
+          #   panic
+
+#log_min_error_statement = error  # values in order of decreasing detail:
+          #   debug5
+          #   debug4
+          #   debug3
+          #   debug2
+          #   debug1
+          #   info
+          #   notice
+          #   warning
+          #   error
+          #   log
+          #   fatal
+          #   panic (effectively off)
+
+#log_min_duration_statement = -1  # -1 is disabled, 0 logs all statements
+          # and their durations, > 0 logs only
+          # statements running at least this number
+          # of milliseconds
+
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default    # terse, default, or verbose messages
+#log_hostname = off
+#log_line_prefix = ''     # special values:
+          #   %a = application name
+          #   %u = user name
+          #   %d = database name
+          #   %r = remote host and port
+          #   %h = remote host
+          #   %p = process ID
+          #   %t = timestamp without milliseconds
+          #   %m = timestamp with milliseconds
+          #   %i = command tag
+          #   %e = SQL state
+          #   %c = session ID
+          #   %l = session line number
+          #   %s = session start timestamp
+          #   %v = virtual transaction ID
+          #   %x = transaction ID (0 if none)
+          #   %q = stop here in non-session
+          #        processes
+          #   %% = '%'
+#log_lock_waits = off     # log lock waits >= deadlock_timeout
+#log_statement = 'none'     # none, ddl, mod, all
+#log_temp_files = -1      # log temporary files equal or larger
+          # than the specified size in kilobytes;
+          # -1 disables, 0 logs all temp files
+log_timezone = '<%= node[:timezone] %>'
+
+
+#------------------------------------------------------------------------------
+# RUNTIME STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query/Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_io_timing = off
+#track_functions = none     # none, pl, all
+#track_activity_query_size = 1024 # (change requires restart)
+#update_process_title = on
+#stats_temp_directory = 'pg_stat_tmp'
+
+
+# - Statistics Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+#autovacuum = on      # Enable autovacuum subprocess?  'on'
+          # requires track_counts to also be on.
+#log_autovacuum_min_duration = -1 # -1 disables, 0 logs all actions and
+          # their durations, > 0 logs only
+          # actions running at least this number
+          # of milliseconds.
+#autovacuum_max_workers = 3   # max number of autovacuum subprocesses
+          # (change requires restart)
+#autovacuum_naptime = 1min    # time between autovacuum runs
+#autovacuum_vacuum_threshold = 50 # min number of row updates before
+          # vacuum
+#autovacuum_analyze_threshold = 50  # min number of row updates before
+          # analyze
+#autovacuum_vacuum_scale_factor = 0.2 # fraction of table size before vacuum
+#autovacuum_analyze_scale_factor = 0.1  # fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000  # maximum XID age before forced vacuum
+          # (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000  # maximum multixact age
+          # before forced vacuum
+          # (change requires restart)
+#autovacuum_vacuum_cost_delay = 20ms  # default vacuum cost delay for
+          # autovacuum, in milliseconds;
+          # -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1  # default vacuum cost limit for
+          # autovacuum, -1 means use
+          # vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#search_path = '"$user",public'   # schema names
+#default_tablespace = ''    # a tablespace name, '' uses the default
+#temp_tablespaces = ''      # a list of tablespace names, '' uses
+          # only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0      # in milliseconds, 0 is disabled
+#lock_timeout = 0     # in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_freeze_table_age = 150000000
+#bytea_output = 'hex'     # hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+
+# - Locale and Formatting -
+
+#datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = '<%= node[:timezone] %>'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+          # abbreviations.  Currently, there are
+          #   Default
+          #   Australia
+          #   India
+          # You can create your own file in
+          # share/timezonesets/.
+#extra_float_digits = 0     # min -15, max 3
+#client_encoding = sql_ascii    # actually, defaults to database
+          # encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.UTF-8'     # locale for system error message
+          # strings
+lc_monetary = 'en_US.UTF-8'     # locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'      # locale for number formatting
+lc_time = 'en_US.UTF-8'       # locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64   # min 10
+          # (change requires restart)
+# Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
+# max_locks_per_transaction * (max_connections + max_prepared_transactions)
+# lock table slots.
+#max_pred_locks_per_transaction = 64  # min 10
+          # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# VERSION/PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding  # on, off, or safe_encoding
+#default_with_oids = off
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#sql_inheritance = on
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off      # terminate session on any error?
+#restart_after_crash = on   # reinitialize after backend crash?
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.
+
+#include_dir = 'conf.d'     # include files ending in '.conf' from
+          # directory 'conf.d'
+#include_if_exists = 'exists.conf'  # include file only if it exists
+#include = 'special.conf'   # include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/cookbooks/postgresql-ha/templates/default/recovery.conf.ctmpl
+++ b/cookbooks/postgresql-ha/templates/default/recovery.conf.ctmpl
@@ -1,0 +1,2 @@
+standby_mode = 'on'
+primary_conninfo = 'host={{ key "postgresql/<%= node[:postgresql][:ha][:cluster] %>/master"}}'

--- a/roles/consul-server.json
+++ b/roles/consul-server.json
@@ -1,0 +1,7 @@
+{
+  "name": "consul-server",
+  "description": "Consul Server Agent",
+  "run_list": [
+    "recipe[consul]"
+  ]
+}


### PR DESCRIPTION
This PR adds consul and postgresql.

Consul should be in added to role base, in each cluster 3 servers should get role "consul-server".

dnsmasq is used to make consul's dns api accessible.

postgresql-ha is using consul to allow for automatic failover. postgresql-ha::client uses pg-bouncer to allow normal clients to just connect to localhost w/o worrying about HA at all. It is design as a drop-in replacement for cookbooks/postgresql, i.e. replace the recipes on your current master, then deploy as many HA nodes as you like.